### PR TITLE
added freecad backup files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/__pycache__/
 SimPanel.bak
+*.FCBak


### PR DESCRIPTION
The .FCBak do not need to be in Git, so no use tracking their changes.